### PR TITLE
Setting up default video url

### DIFF
--- a/lib/probe_connection.rb
+++ b/lib/probe_connection.rb
@@ -138,7 +138,7 @@ class ProbeConnection
           if msg['event'] == "documentReady"
             cmd = <<-EOS
               document.probe.setPlayerSettings({
-                'videoUrl': '#{@settings.video_url}'
+		#{@settings.video_url.is_a? String and @settings.video_url.length > 0 ? "'videoUrl': '#{@settings.video_url}'" : '' }
               })
               document.probe.initializePlayer('#{@settings.technology}')
             EOS


### PR DESCRIPTION
If no video url was given, the probe connection tried to initialize the js script with an empty video url string instead of chosing one of the sample/default ones. Fixed it! :)

Now you can run the software initially without setting up a specific video url. Instead a default url is chosen from the underlying JS library.